### PR TITLE
Added i18n internationalization

### DIFF
--- a/components/Login/CameraModal.js
+++ b/components/Login/CameraModal.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import { StyleSheet, Modal } from 'react-native'
 import { Camera } from 'expo-camera'
 import Layout from '../../constants/Layout'
+import getString from '../../languages'
 
 const CameraModal = ({ isCameraOn, closeCamera, onGetSelfie, destination }) => {
   // eslint-disable-next-line no-unused-vars
@@ -58,7 +59,7 @@ const CameraModal = ({ isCameraOn, closeCamera, onGetSelfie, destination }) => {
         </View> */}
       </Camera>
       <Button borderRadius={10} style={styles.buttonCamera} onPress={getSelfie}>
-        <Text>Tomar foto </Text>
+        <Text>{getString('camera.takePhoto')}</Text>
       </Button>
     </Modal>
   )

--- a/languages/es.js
+++ b/languages/es.js
@@ -15,4 +15,7 @@ export default {
       message: 'Hubo un problema registrandote. Por favor intentalo de nuevo.',
     },
   },
+  camera: {
+    takePhoto: 'Tomar Foto',
+  },
 }

--- a/languages/index.js
+++ b/languages/index.js
@@ -1,0 +1,16 @@
+import i18n from 'i18n-js'
+
+import es from './es'
+
+// Por defecto se usa el idioma español
+i18n.defaultLocale = 'es'
+// Se elige el idioma a usar. A futuro esto se setea en settings
+i18n.locale = 'es'
+
+// Si no está el string apropiado, usa el string en español por defecto
+i18n.fallbacks = true
+// Aqui se incluyen los distintos objetos con los strings
+i18n.translations = { es }
+
+const getString = (key, params) => i18n.t(key, params)
+export default getString

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "expo-font": "^7.0.0",
     "expo-web-browser": "^7.0.0",
     "fonts": "^0.0.2",
+    "i18n-js": "^3.3.0",
     "lodash": "^4.17.15",
     "native-base": "^2.13.8",
     "react": "16.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3578,6 +3578,11 @@ hyphenate-style-name@^1.0.2:
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz#097bb7fa0b8f1a9cf0bd5c734cf95899981a9b48"
   integrity sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ==
 
+i18n-js@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/i18n-js/-/i18n-js-3.3.0.tgz#05512f7184b5117c087ab597be649720a834c068"
+  integrity sha512-+m8jh84IIWlFwEJgwrWCkeIwIES9ilJKBOj5qx8ZTLLmlPz7bjKnCdxf254wRf6M4pkQHtgXGT9r9lGk0e9aug==
+
 iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"


### PR DESCRIPTION
Added [i18n internationalization](https://github.com/fnando/i18n-js).
Usage example:
```js
import getString from '../../languages'
getString('signin.create')
```