### PR TITLE
fix(timestamps): object had etd in etd_info, not trip_times

### DIFF
--- a/components/Trips/Trips.js
+++ b/components/Trips/Trips.js
@@ -24,7 +24,7 @@ class MyTrips extends Component {
             data={this.props.trips}
             renderItem={({ item }) => (
               <Trip
-                timestamp={item.trip_times.etd}
+                timestamp={item.etd_info.etd}
                 spacesUsed={item.spacesUsed}
                 user={item.driver}
                 status={item.trip_status}


### PR DESCRIPTION
El PR en sí es solo una línea, pero había encontrado varios problemas, no alcancé a arreglarlos porque me tengo que ir :( 
Revisar si esto efectivamente seguirá siendo así, ya que no he revisado la documentación, pero con lo que hice dejó de salirme NaN en Mis Viajes.

Hay que revisar los timestamps en todos estos lados y arreglarlos ahí, ya que los objetos con timestamps relacionados ahí sí eran NaN y eso era de backend.

* screens/TripsScreen.js
* components/Trips/Trip/Trip.js
* components/Trips/ChooseTrips.js
* components/Login/LoginForm.js